### PR TITLE
Slow button sync

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -28,7 +28,7 @@ public final class Constants {
     // Driving Parameters - Note that these are not the maximum capable speeds of
     // the robot, rather the allowed maximum speeds
     public static final double kMaxSpeedMetersPerSecond = 2; //4.8
-    public static final double kSlowSpeedMetersPerSecond = 1.5; //2.25
+    public static final double kSlowSpeedMetersPerSecond = .5; //2.25
     public static final double kMaxAngularSpeed = 0.5 * Math.PI; // radians per second 2
 
     // Chassis configuration

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -28,7 +28,7 @@ public final class Constants {
     // Driving Parameters - Note that these are not the maximum capable speeds of
     // the robot, rather the allowed maximum speeds
     public static final double kMaxSpeedMetersPerSecond = 2; //4.8
-    public static final double kSlowSpeedMetersPerSecond = .5; //2.25
+    public static final double kSlowSpeedMetersPerSecond = 1.5; //2.25
     public static final double kMaxAngularSpeed = 0.5 * Math.PI; // radians per second 2
 
     // Chassis configuration

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -28,7 +28,7 @@ public final class Constants {
     // Driving Parameters - Note that these are not the maximum capable speeds of
     // the robot, rather the allowed maximum speeds
     public static final double kMaxSpeedMetersPerSecond = 2; //4.8
-    public static final double kSlowSpeedMetersPerSecond = 2.25; 
+    public static final double kSlowSpeedMetersPerSecond = 1.5; //2.25
     public static final double kMaxAngularSpeed = 0.5 * Math.PI; // radians per second 2
 
     // Chassis configuration

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -108,7 +108,14 @@ public class RobotContainer {
             () -> m_robotDrive.setX(),
             m_robotDrive));
     // While left button is pressed, speed is halved
-    new JoystickButton(m_driverController, Button.kLeftBumper.value).whileTrue(new RunCommand(() -> m_robotDrive.setX(), m_robotDrive));
+    new JoystickButton(m_driverController, Button.kLeftBumper.value)
+        .onTrue(new RunCommand(
+            () -> m_robotDrive.slowTrue(),
+            m_robotDrive));
+    new JoystickButton(m_driverController, Button.kLeftBumper.value)
+        .onFalse(new RunCommand(
+            () -> m_robotDrive.slowFalse(),
+            m_robotDrive));
     //new JoystickButton(m_driverController, Button.kBack.value).onTrue(new StowPosition(m_Arm, m_Claw));
     //new JoystickButton(m_driverController, Button.kStart.value).onTrue(new FloorPosition(m_Arm, m_Claw));
     new JoystickButton(m_gunnerController, Button.kY.value).whileTrue(new ArmUp(m_Arm));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -108,7 +108,7 @@ public class RobotContainer {
             () -> m_robotDrive.setX(),
             m_robotDrive));
     // While left button is pressed, speed is halved
-    //new JoystickButton(m_driverController, Button.kLeftBumper.value);
+    new JoystickButton(m_driverController, Button.kLeftBumper.value).whileTrue(new RunCommand(() -> m_robotDrive.setX(), m_robotDrive));
     //new JoystickButton(m_driverController, Button.kBack.value).onTrue(new StowPosition(m_Arm, m_Claw));
     //new JoystickButton(m_driverController, Button.kStart.value).onTrue(new FloorPosition(m_Arm, m_Claw));
     new JoystickButton(m_gunnerController, Button.kY.value).whileTrue(new ArmUp(m_Arm));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -20,15 +20,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants.AutoConstants;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.OIConstants;
-import frc.robot.commands.ArmDown;
-import frc.robot.commands.ArmUp;
-import frc.robot.commands.ClawDown;
-import frc.robot.commands.ClawUp;
-import frc.robot.commands.CloseClaw;
-import frc.robot.commands.FloorPosition;
-import frc.robot.commands.OpenClaw;
-import frc.robot.commands.ScoreHighPosition;
-import frc.robot.commands.StowPosition;
+import frc.robot.commands.*;
 import frc.robot.subsystems.Arm;
 import frc.robot.subsystems.Gyro;
 import frc.robot.subsystems.Claw;
@@ -108,14 +100,8 @@ public class RobotContainer {
             () -> m_robotDrive.setX(),
             m_robotDrive));
     // While left button is pressed, speed is halved
-    new JoystickButton(m_driverController, Button.kLeftBumper.value)
-        .onTrue(new RunCommand(
-            () -> m_robotDrive.slowTrue(),
-            m_robotDrive));
-    new JoystickButton(m_driverController, Button.kLeftBumper.value)
-        .onFalse(new RunCommand(
-            () -> m_robotDrive.slowFalse(),
-            m_robotDrive));
+    new JoystickButton(m_driverController, Button.kLeftBumper.value).onTrue(new DriveSlow(m_robotDrive));
+    new JoystickButton(m_driverController, Button.kLeftBumper.value).onFalse(new DriveNormal(m_robotDrive));
     //new JoystickButton(m_driverController, Button.kBack.value).onTrue(new StowPosition(m_Arm, m_Claw));
     //new JoystickButton(m_driverController, Button.kStart.value).onTrue(new FloorPosition(m_Arm, m_Claw));
     new JoystickButton(m_gunnerController, Button.kY.value).whileTrue(new ArmUp(m_Arm));

--- a/src/main/java/frc/robot/commands/DriveNormal.java
+++ b/src/main/java/frc/robot/commands/DriveNormal.java
@@ -2,16 +2,16 @@ package frc.robot.commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.robot.subsystems.DriveSubsystem;
 
-public class DriveSlow extends InstantCommand {
+public class DriveNormal extends InstantCommand {
     private final DriveSubsystem m_DriveSubsystem;
 
-    public DriveSlow(DriveSubsystem theDriveSubsystem) {
+    public DriveNormal(DriveSubsystem theDriveSubsystem) {
         m_DriveSubsystem = theDriveSubsystem;
         addRequirements(m_DriveSubsystem);
     }
 
     @Override
     public void initialize() {
-        m_DriveSubsystem.slowEnable = true;
+        m_DriveSubsystem.slowEnable = false;
     }
 }

--- a/src/main/java/frc/robot/commands/DriveSlow.java
+++ b/src/main/java/frc/robot/commands/DriveSlow.java
@@ -11,12 +11,7 @@ public class DriveSlow extends CommandBase{
     }
 
     @Override
-    public void initialize() {
+    public void execute() {
         m_DriveSubsystem.slowTrue();
-    }
-
-    @Override
-    public void end(boolean done) {
-        m_DriveSubsystem.slowFalse();
     }
 }

--- a/src/main/java/frc/robot/commands/DriveSlow.java
+++ b/src/main/java/frc/robot/commands/DriveSlow.java
@@ -1,0 +1,22 @@
+package frc.robot.commands;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.DriveSubsystem;
+
+public class DriveSlow extends CommandBase{
+    private final DriveSubsystem m_DriveSubsystem;
+
+    public DriveSlow(DriveSubsystem theDriveSubsystem) {
+        m_DriveSubsystem = theDriveSubsystem;
+        addRequirements(m_DriveSubsystem);
+    }
+
+    @Override
+    public void initialize() {
+        m_DriveSubsystem.slowTrue();
+    }
+
+    @Override
+    public void end(boolean done) {
+        m_DriveSubsystem.slowFalse();
+    }
+}

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -162,19 +162,19 @@ public void slowFalse(){
   
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
     // Adjust input based on max speed
-    if(slowEnable.get()){
-      xSpeed *= DriveConstants.kSlowSpeedMetersPerSecond;
-      ySpeed *= DriveConstants.kSlowSpeedMetersPerSecond;
-    }
-    else{
-      xSpeed *= DriveConstants.kMaxSpeedMetersPerSecond;
-      ySpeed *= DriveConstants.kMaxSpeedMetersPerSecond;
-    }
+    xSpeed *= DriveConstants.kMaxSpeedMetersPerSecond;
+    ySpeed *= DriveConstants.kMaxSpeedMetersPerSecond;
+    
     rot *= DriveConstants.kMaxAngularSpeed;
     // Non linear speed set
     xSpeed *= Math.signum(xSpeed)*Math.pow(xSpeed,3);
     ySpeed *= Math.signum(ySpeed)*Math.pow(ySpeed,3);
     
+    if(slowEnable.get())
+    {
+      xSpeed *= 3/4;
+      ySpeed *= 3/4;
+    }
   
    
     var swerveModuleStates = DriveConstants.kDriveKinematics.toSwerveModuleStates(

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -21,7 +21,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DriveSubsystem extends SubsystemBase {
-  private AtomicBoolean slowEnable = new AtomicBoolean();
+  
 
   // Create MAXSwerveModules
   private final MAXSwerveModule m_frontLeft = new MAXSwerveModule(
@@ -140,6 +140,13 @@ public class DriveSubsystem extends SubsystemBase {
     }
   }
 
+public void slowTrue(){
+  slowEnable.set(true);
+}
+
+public void slowFalse(){
+  slowEnable.set(false);
+}
 
   /**
    * Method to drive the robot using joystick info.
@@ -150,6 +157,9 @@ public class DriveSubsystem extends SubsystemBase {
    * @param fieldRelative Whether the provided x and y speeds are relative to the
    *                      field.
    */
+  private AtomicBoolean slowEnable = new AtomicBoolean();
+  
+  
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
     // Adjust input based on max speed
     xSpeed *= DriveConstants.kMaxSpeedMetersPerSecond;
@@ -158,10 +168,9 @@ public class DriveSubsystem extends SubsystemBase {
     // Non linear speed set
     xSpeed *= Math.signum(xSpeed)*Math.pow(xSpeed,3);
     ySpeed *= Math.signum(ySpeed)*Math.pow(ySpeed,3);
-    if ( slowEnable.get() ) {
-        xSpeed /= 4;
-        ySpeed /= 4;
-    }
+
+  
+   
     var swerveModuleStates = DriveConstants.kDriveKinematics.toSwerveModuleStates(
         fieldRelative
             ? ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot, Rotation2d.fromDegrees(m_gyro.getAngle()))

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -21,7 +21,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DriveSubsystem extends SubsystemBase {
-  
+  private AtomicBoolean slowEnable = new AtomicBoolean();
 
   // Create MAXSwerveModules
   private final MAXSwerveModule m_frontLeft = new MAXSwerveModule(
@@ -157,18 +157,24 @@ public void slowFalse(){
    * @param fieldRelative Whether the provided x and y speeds are relative to the
    *                      field.
    */
-  private AtomicBoolean slowEnable = new AtomicBoolean();
+ 
   
   
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
     // Adjust input based on max speed
-    xSpeed *= DriveConstants.kMaxSpeedMetersPerSecond;
-    ySpeed *= DriveConstants.kMaxSpeedMetersPerSecond;
+    if(slowEnable.get()){
+      xSpeed *= DriveConstants.kSlowSpeedMetersPerSecond;
+      ySpeed *= DriveConstants.kSlowSpeedMetersPerSecond;
+    }
+    else{
+      xSpeed *= DriveConstants.kMaxSpeedMetersPerSecond;
+      ySpeed *= DriveConstants.kMaxSpeedMetersPerSecond;
+    }
     rot *= DriveConstants.kMaxAngularSpeed;
     // Non linear speed set
     xSpeed *= Math.signum(xSpeed)*Math.pow(xSpeed,3);
     ySpeed *= Math.signum(ySpeed)*Math.pow(ySpeed,3);
-
+    
   
    
     var swerveModuleStates = DriveConstants.kDriveKinematics.toSwerveModuleStates(

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -170,12 +170,15 @@ public void slowFalse(){
     xSpeed *= Math.signum(xSpeed)*Math.pow(xSpeed,3);
     ySpeed *= Math.signum(ySpeed)*Math.pow(ySpeed,3);
     
+    System.out.println("Prior to slow check");
     if(slowEnable.get())
     {
       xSpeed *= 3/4;
       ySpeed *= 3/4;
       System.out.println("here" + xSpeed + ySpeed);
+      System.out.println("SLOW APPLIED");
     }
+    System.out.println("After slow check");
   
    
     var swerveModuleStates = DriveConstants.kDriveKinematics.toSwerveModuleStates(

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -21,7 +21,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DriveSubsystem extends SubsystemBase {
-  static AtomicBoolean slowEnable = new AtomicBoolean();
+  private AtomicBoolean slowEnable = new AtomicBoolean();
 
   // Create MAXSwerveModules
   private final MAXSwerveModule m_frontLeft = new MAXSwerveModule(

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -18,8 +18,11 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Robot;
 import frc.robot.Constants.DriveConstants;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DriveSubsystem extends SubsystemBase {
+  static AtomicBoolean slowEnable = new AtomicBoolean();
+
   // Create MAXSwerveModules
   private final MAXSwerveModule m_frontLeft = new MAXSwerveModule(
       DriveConstants.kFrontLeftDrivingCanId,
@@ -155,11 +158,10 @@ public class DriveSubsystem extends SubsystemBase {
     // Non linear speed set
     xSpeed *= Math.signum(xSpeed)*Math.pow(xSpeed,3);
     ySpeed *= Math.signum(ySpeed)*Math.pow(ySpeed,3);
-    /**if(kLeftBumper.value){
-    *  xSpeed /= 2;
-    *  ySpeed /= 2;
-    *};
-    */
+    if ( slowEnable.get() ) {
+        xSpeed /= 4;
+        ySpeed /= 4;
+    }
     var swerveModuleStates = DriveConstants.kDriveKinematics.toSwerveModuleStates(
         fieldRelative
             ? ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot, Rotation2d.fromDegrees(m_gyro.getAngle()))

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -174,6 +174,7 @@ public void slowFalse(){
     {
       xSpeed *= 3/4;
       ySpeed *= 3/4;
+      System.out.println("here" + xSpeed + ySpeed);
     }
   
    

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -18,10 +18,9 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Robot;
 import frc.robot.Constants.DriveConstants;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DriveSubsystem extends SubsystemBase {
-  private AtomicBoolean slowEnable = new AtomicBoolean();
+  public boolean slowEnable = false;
 
   // Create MAXSwerveModules
   private final MAXSwerveModule m_frontLeft = new MAXSwerveModule(
@@ -140,14 +139,6 @@ public class DriveSubsystem extends SubsystemBase {
     }
   }
 
-public void slowTrue(){
-  slowEnable.set(true);
-}
-
-public void slowFalse(){
-  slowEnable.set(false);
-}
-
   /**
    * Method to drive the robot using joystick info.
    *
@@ -170,15 +161,11 @@ public void slowFalse(){
     xSpeed *= Math.signum(xSpeed)*Math.pow(xSpeed,3);
     ySpeed *= Math.signum(ySpeed)*Math.pow(ySpeed,3);
     
-    System.out.println("Prior to slow check");
-    if(slowEnable.get())
+    if(slowEnable)
     {
-      xSpeed *= 3/4;
-      ySpeed *= 3/4;
-      System.out.println("here" + xSpeed + ySpeed);
-      System.out.println("SLOW APPLIED");
+      xSpeed *= 3.0/4.0;
+      ySpeed *= 3.0/4.0;
     }
-    System.out.println("After slow check");
   
    
     var swerveModuleStates = DriveConstants.kDriveKinematics.toSwerveModuleStates(


### PR DESCRIPTION
Adds a slow set mode active when the left trigger is pressed.

This utilizes [InstantCommands](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj2/command/InstantCommand.html) that fire when the trigger state changes and set a condition to multiply current speeds by 3/4%. This 3/4s number should be made a constant and tweaked according to the driver's preference.

CHANGES FROM INITIAL CONCEPT:
- AtomicBoolean was replaced with a regular boolean. [addRequirements](https://first.wpi.edu/wpilib/allwpilib/docs/release/java/edu/wpi/first/wpilibj2/command/CommandBase.html#addRequirements(edu.wpi.first.wpilibj2.command.Subsystem...)) evidently acts as a [mutex](https://en.wikipedia.org/wiki/Lock_(computer_science)), so this is a safe action.
- The type of command was narrowed down to InstantCommand. Non-instant commands do not finish after firing, they continue until cancelled. Continuing until cancelled locks the drivetrain system, preventing the main drive methods from accessing it, until released (when used while whileTrue) or forever (when used with onTrue).
- The operation was changed to use 3.0/4.0 instead of 3/4. 3/4 is integer division and will always round down to an integer zero. 3.0/4.0 is floating point division and will be approximately 0.75 in floating point.

Note: prior code added an adjustment for non-linear speed changes. Check that the drive team wants this, and that it is tuned to their liking.